### PR TITLE
[ISSUE-5] #5 작업

### DIFF
--- a/src/components/content/posts-normal-permalink-item/posts-normal-permalink-item.component.tsx
+++ b/src/components/content/posts-normal-permalink-item/posts-normal-permalink-item.component.tsx
@@ -115,6 +115,7 @@ export function PostsNormalPermalinkItem() {
           className={classes(
             "contents-wrapper-container",
             "[##_var_is_codeblock_copy_button_show_##]",
+            "[##_var_darkmode_post_table_style_##]",
             "block m-0 p-0 relative [##_var_post_youtube_horizontal_align_##]",
             "[##_var_is_post_codeblock_darkmode_text_color_all_white_##]",
           )}>

--- a/src/components/content/posts-notice-permalink-item/posts-notice-permalink-item.component.tsx
+++ b/src/components/content/posts-notice-permalink-item/posts-notice-permalink-item.component.tsx
@@ -113,6 +113,7 @@ export function PostsNoticePermalinkItem() {
           className={classes(
             "contents-wrapper-container",
             "[##_var_is_codeblock_copy_button_show_##]",
+            "[##_var_darkmode_post_table_style_##]",
             "block m-0 p-0 relative [##_var_post_youtube_horizontal_align_##]",
             "[##_var_is_post_codeblock_darkmode_text_color_all_white_##]",
           )}>

--- a/src/components/content/posts/posts.component.tsx
+++ b/src/components/content/posts/posts.component.tsx
@@ -10,7 +10,11 @@ import { PostsProtectedPermalinkItem } from "../posts-protected-permalink-item/p
 export function Posts() {
   return (
     <>
-      <div className="w-full block relative [##_var_total_list_max_col_count_##]">
+      <div 
+        className={classes(
+          "w-full block relative",
+          "[##_var_total_list_max_col_count_##]",
+        )}>
         <ul
           // posts-list
           className={classes(

--- a/src/components/layout/side-bar/side-bar.scss
+++ b/src/components/layout/side-bar/side-bar.scss
@@ -91,3 +91,41 @@
     display: none !important;
   }
 }
+
+html {
+  #common-side-bar {
+    .module.module_plugin {
+      border-bottom: 1px solid #000;
+      padding-bottom: 1.5rem;
+    }
+  }
+
+  &.dark {
+    #common-side-bar {
+      .module.module_plugin {
+        border-bottom: 1px solid #fff;
+
+        svg {
+          g[stroke='\#000000'] {
+            path {
+              stroke: #fff;
+              stroke-opacity: 1;
+            }
+
+            &[stroke-opacity='0'] {
+              path {
+                stroke-opacity: 0;
+              } 
+            }
+          }
+
+          g[fill='\#000000'] {
+            text {
+              fill: #fff;
+            }
+          }
+        }
+      }
+    } 
+  }
+}

--- a/src/index.script.tsx
+++ b/src/index.script.tsx
@@ -308,6 +308,7 @@ function checkDarkModeFontColor() {
 function checkFigureTags(isExecute?: boolean) {
   if (isExecute !== true) return;
 
+  // 정렬 셋팅
   const figuresEmoticon = document.querySelectorAll<HTMLElement>('.contents-wrapper-container .contents_style > figure[data-ke-type="emoticon"]');
   const figuresYoutubePlugin = document.querySelectorAll<HTMLElement>('.contents-wrapper-container .contents_style > figure[data-ke-type="video"]');
   

--- a/src/index.scss
+++ b/src/index.scss
@@ -53,9 +53,29 @@
         margin-bottom: 12px;
       }
 
+      > blockquote {
+        // &[data-ke-style='style1'] {
+        //   color: #ccc !important; 
+        // }
+
+        &[data-ke-style='style2'] {
+          color: #999;
+          border-left: 4px solid #CACACA;
+          padding: 4px 12px;
+          position: relative;
+        }
+
+        // &[data-ke-style='style3'] {
+        //   background-color: transparent;
+        //   color: #ccc !important; 
+        // }
+      }
+
       > table {
+        color: #333;
         border-top: 1px solid #444;
         border-left: 1px solid #444;
+        background-color: #fff;
 
         > tbody {
           > tr {
@@ -174,6 +194,14 @@
           }
         }
 
+        > figure[data-ke-type='opengraph'] {
+          .og-text {
+            .og-title {
+              color: #fff !important;
+            }
+          }
+        }
+
         > pre[data-ke-type='codeblock'] {
           border: 1px solid #fff;
           background-color: transparent;
@@ -221,25 +249,42 @@
             color: #ccc !important; 
           }
         }
+      }
 
-        > table {
-          border-top: 1px solid #fff;
-          border-left: 1px solid #fff;
-
-          > tbody {
-            > tr {
-              > td {
-                background-color: transparent !important;
-                color: #fff !important;
-                border-right: 1px solid #fff;
-                border-bottom: 1px solid #fff;
-              }
-
-              &:first-child {
+      &.darkmode_post_table_style_auto_convert {
+        .contents_style {
+          > table {
+            border-top: 1px solid #fff;
+            border-left: 1px solid #fff;
+            background-color: transparent;
+  
+            > tbody {
+              > tr {
                 > td {
-                  border-top: 1px solid #fff;
-                  border-left: 1px solid #fff;
+                  background-color: transparent !important;
+                  color: #fff !important;
+                  border-right: 1px solid #fff;
+                  border-bottom: 1px solid #fff;
                 }
+  
+                &:first-child {
+                  > td {
+                    border-top: 1px solid #fff;
+                    border-left: 1px solid #fff;
+                  }
+                }
+
+                &:nth-child(odd) {
+                  > td {
+                    border-bottom: 1px solid #999 !important;
+                  }
+                }
+
+                &:nth-child(even) {
+                  > td {
+                    border-bottom: 1px solid #fff !important;
+                  }
+                } 
               }
             }
           }

--- a/src/public/index.xml
+++ b/src/public/index.xml
@@ -185,6 +185,21 @@
         ]]></option>
         <default>is_codeblock_copy_button_show_true</default>
       </variable>
+      <variable>
+        <name>darkmode_post_table_style</name>
+        <label>
+          <![CDATA[ 다크모드시 본문글의 테이블 스타일 처리 방식 ]]>
+        </label>
+        <description>다크모드시 본문글의 테이블 스타일 처리 방식</description>
+        <type>SELECT</type>
+        <option><![CDATA[
+          [
+            {"name":"darkmode_post_table_style_original_color_keep", "label":"본래 테이블 스타일을 유지", "value":"darkmode_post_table_style_original_color_keep"},
+            {"name":"darkmode_post_table_style_auto_convert", "label":"다크모드에 맞게 스타일 자동 수정", "value":"darkmode_post_table_style_auto_convert"}
+          ]
+        ]]></option>
+        <default>darkmode_post_table_style_auto_convert</default>
+      </variable>
     </variablegroup>
     <variablegroup name="홈커버 아이템 옵션">
       <variable>


### PR DESCRIPTION
#5 작업을 다음과 같이 진행하였습니다.

1. 다크모드시 본문글에서 URL 미리보기에 해당하는 부분의 타이틀이 흰색으로 적용되도록 수정하였습니다.
2. 다크모드시 본문글의 table 스타일을 다크모드에 맞춰 자동으로 변경할지 아니면 본래 table 스타일을 그대로 유지시킬지에 대한 스킨 옵션이 추가되었습니다. 
![image](https://github.com/wisdomstar94/torytis-tistory-skin-stroke/assets/93423564/a1b3568a-6184-48f1-be22-da9e70112cba)
또한 다크모드에 맞춰 자동으로 변경될 경우 홀수번째 행의 border bottom 색상과 짝수번째 행의 border bottom 색의 차이를 주었습니다.
![image](https://github.com/wisdomstar94/torytis-tistory-skin-stroke/assets/93423564/66ea5ec9-9f7c-43e7-87fa-fb24648c50bd)
3. 본물글에서 일부 인용문의 스타일을 일반 텍스트와 구분되도록 변경하였습니다.
-- 에디터 화면
![image](https://github.com/wisdomstar94/torytis-tistory-skin-stroke/assets/93423564/2e1d95b8-7e94-40cf-ae7d-786106ad3155)
-- 실제 본문글에서 렌더링된 화면
![image](https://github.com/wisdomstar94/torytis-tistory-skin-stroke/assets/93423564/7045989d-0974-410e-97e8-b78db0bb9dc1)
4. 티스토리에서 제공하는 방문자 그래프 플러그인도 다크모드 대응 작업을 진행하였습니다.
![image](https://github.com/wisdomstar94/torytis-tistory-skin-stroke/assets/93423564/6d3146a6-d12a-443f-9e05-4016f2c2de8f)
 
